### PR TITLE
Method mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ test/*.js
 *ncrunch*
 *crunch*.local.xml
 
+# coverage
+coverage
+
 # visual studio database projects
 *.dbmdl
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,56 @@
 
 [![Build Status](https://travis-ci.org/midknight41/cooperate.svg?branch=master)](https://travis-ci.org/midknight41/cooperate)
 
-**cooperate** is a convention based composition tool that let's you compose a series of objects into a single object quickly. It does not alter the original objects or prototypes but wraps them in a proxy object. The proxy will perserve the appropriate getters and setters from the original object.
-
-If method/properties/attributes begin or end with an "_" then they will not be exposed on the proxy object.
-
-Note: At present naming collisions are considered errors.
+**cooperate** is a convention based composition tool that let's you compose a series of objects into a single object quickly. It does not alter the original objects or prototypes but wraps them in a proxy object. The proxy object will forward the method calls to the appropriate underlying object methods and perserves the appropriate behaviour of your getters and setters too.
 
 ## Installation
 ```
 npm install cooperate -S
 ```
 
-## Example
+## Why use it?
+
+Inheritance can be a bit of a pain for many reasons and a great alternative is to use composition. This is traditionally done like this:
+
+```js
+class MainClass {
+
+  constructor(capability1, capability2) {
+    this.capability1_ = capability1;
+    this.capability2_ = capability2;
+  }
+
+  doStuff(value) {
+    this.capability1_.doStuff(value);
+  }
+
+  doMoreStuff(value) {
+    this.capability2_.doMoreStuff(value);
+  }
+
+}
+
+const capability1 = new Capability1();
+const capability2 = new Capability2();
+
+const combined = new MainClass(capability1, capability2);
+```
+
+While this approach avoids some of the pain points of inheritance it does require you do a lot of method forwarding which is repetitive, time-consuming and boring. That's where **cooperate** comes in. **cooperate** inspects the objects that you would like to combine and does all that method forwarding for you with a single line of code. 
+
+```js
+
+import { compose } from "cooperate";
+
+const capability1 = new Capability1();
+const capability2 = new Capability2();
+
+const combined = compose(capability1, capability2);
+```
+
+JavaScript does not really have the concept of privacy but it is very common for developers to use an ```_``` to mark methods as private. **cooperate** follows this convention and will not expose anything that begins or ends with an ```_``` on the combined object.
+
+## Detailed Example
 ```js
 import { compose } from "cooperate";
 import assert from "assert";
@@ -61,58 +99,64 @@ const specificFeatures = new SpecificFeatures(db);
 
 const repo = compose(genericFeatures, specificFeatures);
 
-// Creates an object with no shared state and does not expose private methods
+// Creates an object with no shared state
 assert(repo.findById);
 assert(repo.getSalesByRegion);
 assert(repo.insert);
 assert(Object.getOwnPropertyDescriptor(repo, "connected"));
 
-// private items are not exposed
-assert((repo.formatQuery_ === undefined));
+// private members are not exposed
+assert(repo.formatQuery_ === undefined);
 assert(Object.getOwnPropertyDescriptor(repo, "_db") === undefined);
 ```
 
 ## Dealing with naming collisions
 
-### Normal Example
+With any form of composition you will eventually come across a problem with two things that have the same name. **cooperate** will throw an error if you try and do this as it cannot decide what to do without your help. 
+
+To help with this problem, **cooperate** provides the ```mapMembers()``` function.
+
+### Example 1
+
 ```js
+import { compose, mapMembers } from "cooperate";
 
-const genericFeatures = mapMembers(new GenericFeatures(db))
-  .map("findById").to("findSalesById");
-
+const genericFeatures = new GenericFeatures(db);
 const specificFeatures = new SpecificFeatures(db);
 
-const repo = compose(genericFeatures, specificFeatures);
+const genericWithMapping = mapMembers(genericFeatures)
+  .map("findById").to("findSalesById");
+
+const repo = compose(genericWithMapping, specificFeatures);
 
 // Method is remapped
 assert(repo.findSalesById);
-assert((repo.findById === undefined));
+assert(repo.findById === undefined);
 
 ```
 
-### Complicated example
+### Example 2
+
 ```js
 
-import { compose, mapMethods } from "cooperate";
+import { compose, mapMembers } from "cooperate";
 import createRepo from "./Repo";
 
 const product = createRepo("products");
 const sale = createRepo("sales");
 
-const productWithMapping = mapMethods(product)
+const productWithMapping = mapMembers(product)
   .map("getItem").to("getProduct")
   .map("updateItem").to("updateProduct")
   .map("insertItem").to("insertProduct")
   .map("deleteItem").to("deleteProduct");
 
-const salesWithMapping = mapMethods(sale)
+const salesWithMapping = mapMembers(sale)
   .map("getItem").to("getSale")
   .map("updateItem").to("updateSale")
   .map("insertItem").to("insertSale")
-  .hide("deleteItem");
+  .map("deleteItem").to("deleteSale");
 
 const combinedRepo = compose(productWithMapping, salesWithMapping);
 
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -71,3 +71,48 @@ assert(Object.getOwnPropertyDescriptor(repo, "connected"));
 assert((repo.formatQuery_ === undefined));
 assert(Object.getOwnPropertyDescriptor(repo, "_db") === undefined);
 ```
+
+## Dealing with naming collisions
+
+### Normal Example
+```js
+
+const genericFeatures = mapMembers(new GenericFeatures(db))
+  .map("findById").to("findSalesById");
+
+const specificFeatures = new SpecificFeatures(db);
+
+const repo = compose(genericFeatures, specificFeatures);
+
+// Method is remapped
+assert(repo.findSalesById);
+assert((repo.findById === undefined));
+
+```
+
+### Complicated example
+```js
+
+import { compose, mapMethods } from "cooperate";
+import createRepo from "./Repo";
+
+const product = createRepo("products");
+const sale = createRepo("sales");
+
+const productWithMapping = mapMethods(product)
+  .map("getItem").to("getProduct")
+  .map("updateItem").to("updateProduct")
+  .map("insertItem").to("insertProduct")
+  .map("deleteItem").to("deleteProduct");
+
+const salesWithMapping = mapMethods(sale)
+  .map("getItem").to("getSale")
+  .map("updateItem").to("updateSale")
+  .map("insertItem").to("insertSale")
+  .hide("deleteItem");
+
+const combinedRepo = compose(productWithMapping, salesWithMapping);
+
+```
+
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "prebuild": "npm run clean",
     "build": "babel ./src -d dist",
     "clean": "./node_modules/.bin/rimraf dist/*",
+    "precover": "npm run build",
+    "cover": "istanbul cover ./node_modules/lab/bin/lab ./dist/test --leaks",
     "pret": "npm run build",
     "t": "lab ./dist/test/ -v -S --assert code",
     "pretest": "npm run build",
@@ -40,7 +42,8 @@
   },
   "homepage": "https://github.com/midknight41/cooperate#readme",
   "dependencies": {
-    "examine-instance": "^0.0.1"
+    "examine-instance": "^0.0.1",
+    "istanbul": "^0.4.5"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cooperate",
   "version": "0.1.1",
-  "description": "Convention based composition utility",
+  "description": "Convention based composition tool that let's you compose a series of objects into a single object quickly.",
   "main": "./dist/lib/index.js",
   "scripts": {
     "prebuild": "npm run clean",

--- a/src/lib/MemberMap.js
+++ b/src/lib/MemberMap.js
@@ -1,0 +1,25 @@
+export default class MemberMap {
+
+  constructor(parent, sourceName) {
+
+    if (!sourceName) {
+      throw new Error("the source field name cannot be null");
+    }
+
+    this.sourceName = sourceName;
+    this.parent_ = parent;
+  }
+
+  to(targetName) {
+
+    if (!targetName || typeof targetName !== "string") {
+      throw new Error("the target field name must be a string");
+    }
+
+    this.targetName = targetName;
+
+    return this.parent_;
+
+  }
+
+}

--- a/src/lib/MemberMaps.js
+++ b/src/lib/MemberMaps.js
@@ -1,0 +1,29 @@
+import assert from "assert";
+import MemberMap from "./MemberMap";
+
+export default class MemberMaps {
+
+  constructor(sourceObject) {
+
+    assert(sourceObject, "sourceObject is required");
+
+    this.sourceObject = sourceObject;
+    this.mappings = new Map();
+  }
+
+  map(sourceName) {
+
+    const mapping = new MemberMap(this, sourceName);
+    this.registerMapping(mapping);
+
+    return mapping;
+
+  }
+
+  registerMapping(mapping) {
+
+    this.mappings.set(mapping.sourceName, mapping);
+  }
+
+}
+

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,55 +1,85 @@
 import examine from "examine-instance";
 import assert from "assert";
+import MemberMaps from "./MemberMaps";
 
 const noPrivate = /^_|_$/;
 
-function forwardMethods(target, sourceObject, index, methods) {
+function forwardMethods(target, sourceObject, index, methods, mappings) {
 
   for (let i = 0; i < methods.length; i++) {
 
-    const method = methods[i];
+    const sourceMethod = methods[i];
 
     // Ditch private methods
-    const isPrivate = noPrivate.exec(method);
+    const isPrivate = noPrivate.exec(sourceMethod);
     if (isPrivate) continue;
 
-    if (target[method] !== undefined) throw new Error(`overriding the existing method '${method}' is not allowed.`);
+    // Re-map methods if mapping rules have been provided
+    let targetMethod = sourceMethod;
 
-    target[method] = function (...params) { return this.__cooperate[index][method](...params); };
+    if (mappings !== null && mappings.has(sourceMethod)) {
+      targetMethod = mappings.get(sourceMethod).targetName;
+    }
+
+    if (target[targetMethod] !== undefined) throw new Error(`Naming collision detected with '${sourceMethod}'. Collisions can be resolved using mapMembers().`);
+
+    target[targetMethod] = function (...params) { return this.__cooperate[index][sourceMethod](...params); };
 
   }
 
 }
 
-function forwardProperties(target, sourceObject, index, props, accessors) {
+function forwardProperties(target, sourceObject, index, props, accessors, mappings) {
 
   for (let i = 0; i < props.length; i++) {
 
-    const prop = props[i];
+    const sourceProp = props[i];
 
     // Ditch private methods
-    const isPrivate = noPrivate.exec(prop);
+    const isPrivate = noPrivate.exec(sourceProp);
     if (isPrivate) continue;
 
-    if (target[prop] !== undefined) throw new Error(`overriding the existing property/attribute '${prop}' is not allowed.`)
 
-    if (accessors.length === 0) return;
+    // Re-map methods if mapping rules have been provided
+    let targetProp = sourceProp;
+
+    if (mappings !== null && mappings.has(sourceProp)) {
+      targetProp = mappings.get(sourceProp).targetName;
+    }
+
+    if (target[targetProp] !== undefined) throw new Error(`Naming collision detected with '${sourceProp}'. Collisions can be resolved using mapMembers().`);
 
     const descriptor = {};
 
     if (accessors.indexOf("get") > -1) {
       descriptor.get = function () {
-        return this.__cooperate[index][prop];
+        return this.__cooperate[index][sourceProp];
       };
     }
 
     if (accessors.indexOf("set") > -1) {
-      descriptor.set = function (value) { this.__cooperate[index][prop] = value; };
+      descriptor.set = function (value) { this.__cooperate[index][sourceProp] = value; };
     }
 
-    Object.defineProperty(target, prop, descriptor);
+    Object.defineProperty(target, targetProp, descriptor);
 
   }
+
+}
+
+function mapAllMembers(wrapper, obj, mappings) {
+
+  wrapper.__cooperate.push(obj);
+  const examination = examine(obj);
+
+  // create proxies to forward all methods, properties and attributes
+  const currentIndex = wrapper.__cooperate.length - 1;
+
+  forwardMethods(wrapper, obj, currentIndex, examination.methods, mappings);
+  forwardProperties(wrapper, obj, currentIndex, examination.readWrite, ["get", "set"], mappings);
+  forwardProperties(wrapper, obj, currentIndex, examination.attributes, ["get", "set"], mappings);
+  forwardProperties(wrapper, obj, currentIndex, examination.readOnly, ["get"], mappings);
+  forwardProperties(wrapper, obj, currentIndex, examination.writeOnly, ["set"], mappings);
 
 }
 
@@ -62,22 +92,20 @@ export function compose(...objects) {
   for (const obj of objects) {
 
     assert(obj, "null and undefined are not allowed");
+    assert(typeof obj === "object", "only objects are supported for composition");
 
-    wrapper.__cooperate.push(obj);
-
-    const examination = examine(obj);
-
-    // create proxies to forward all methods, properties and attributes
-    const currentIndex = wrapper.__cooperate.length - 1;
-
-    forwardMethods(wrapper, obj, currentIndex, examination.methods);
-    forwardProperties(wrapper, obj, currentIndex, examination.readWrite, ["get", "set"]);
-    forwardProperties(wrapper, obj, currentIndex, examination.attributes, ["get", "set"]);
-    forwardProperties(wrapper, obj, currentIndex, examination.readOnly, ["get"]);
-    forwardProperties(wrapper, obj, currentIndex, examination.writeOnly, ["set"]);
+    if (obj instanceof MemberMaps) {
+      mapAllMembers(wrapper, obj.sourceObject, obj.mappings);
+    } else {
+      mapAllMembers(wrapper, obj, null);
+    }
 
   }
 
   return wrapper;
 
+}
+
+export function mapMembers(sourceObject) {
+  return new MemberMaps(sourceObject);
 }

--- a/src/test/mapMembers-test.js
+++ b/src/test/mapMembers-test.js
@@ -1,0 +1,133 @@
+import { expect } from "code";
+import * as Lab from "lab";
+import getHelper from "lab-testing";
+import { compose, mapMembers } from "../lib";
+
+const lab = exports.lab = Lab.script();
+const testing = getHelper(lab);
+const group = testing.createExperiment("cooperate");
+
+class TestClass {
+
+  constructor(uniqueValue) {
+    this.uniqueValue_ = uniqueValue;
+  }
+
+  getItem(id) {
+    return `${this.uniqueValue_}-${id}`;
+  }
+
+  get uniqueValue() { return this.uniqueValue_; }
+}
+
+group("The mapMembers() function", () => {
+
+  testing.throws.functionParameterTest(mapMembers, ["sourceObject"], {});
+
+  let descriptor;
+
+  lab.beforeEach(done => {
+
+    const obj = new TestClass("object-1");
+
+    descriptor = mapMembers(obj);
+
+    return done();
+
+  });
+
+  lab.test("can properly register a mapping", done => {
+
+    const sourceName = "getItem";
+    const targetName = "getTestItem";
+
+    descriptor
+      .map(sourceName).to(targetName);
+
+    expect(descriptor).to.be.an.object();
+    expect(descriptor.mappings.get(sourceName).sourceName).to.equal(sourceName);
+    expect(descriptor.mappings.get(sourceName).targetName).to.equal(targetName);
+
+    return done();
+
+  });
+
+  lab.experiment("when used with compose()", () => {
+
+    let raw;
+
+    lab.beforeEach(done => {
+
+      const obj = new TestClass("object-1");
+
+      descriptor = mapMembers(obj);
+
+      descriptor
+        .map("getItem").to("getTestItem")
+        .map("uniqueValue").to("moreUniqueValue");
+
+      raw = new TestClass("raw-object-1");
+
+      return done();
+
+    });
+
+    lab.test("the cooperate wrapper is correct", done => {
+
+      const result = compose(raw, descriptor);
+
+      expect(result).to.be.an.object();
+      expect(result.__cooperate).to.be.an.array();
+      expect(result.__cooperate).to.have.length(2);
+
+      return done();
+
+    });
+
+    lab.test("the mapping of a method alters the output of compose correctly", done => {
+
+      const result = compose(raw, descriptor);
+
+      expect(result.getItem).to.be.a.function();
+      expect(result.getTestItem).to.be.a.function();
+      expect(result.getItem(1)).to.equal("raw-object-1-1");
+      expect(result.getTestItem(1)).to.equal("object-1-1");
+
+      return done();
+
+    });
+
+    lab.test("the mapping of a property alters the output of compose correctly", done => {
+
+      const result = compose(raw, descriptor);
+
+      expect(result.uniqueValue).to.equal("raw-object-1");
+      expect(result.moreUniqueValue).to.equal("object-1");
+
+      return done();
+
+    });
+
+  });
+
+});
+
+group("The map() method", () => {
+
+  const obj = new TestClass();
+  const descriptor = mapMembers(obj);
+
+  testing.throws.methodParameterTest(descriptor, descriptor.map, ["from"], "abc");
+
+});
+
+group("The to() method", () => {
+
+  const obj = new TestClass();
+  const descriptor = mapMembers(obj);
+
+  const mapping = descriptor.map("abc");
+
+  testing.throws.methodParameterTest(mapping, mapping.to, ["to"], "abc");
+
+});


### PR DESCRIPTION
This PR adds the ```mapMembers()``` function to allow the developer to deal with naming collisions.

It also improves the error handling as raised in #1 