### PR TITLE
V2: Change to compose signature and hide option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### 2.0.0
+
+The method signature for compose has been changed from a parameter array to a normal array of objects. This is to allow a set of options to be used when calling compose. This is a **breaking change**. 
+
+Old Code:
+
+```js
+  const result = compose(a, b);
+```
+
+New Code:
+
+```js
+  const result = compose([a, b]);
+```
+
 ### 1.1.0
 
 Added ```hide()``` method for ```mapMembers()```.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,36 @@
 ### 2.0.0
 
-The method signature for compose has been changed from a parameter array to a normal array of objects. This is to allow a set of options to be used when calling compose. This is a **breaking change**. 
+The method signature for compose has been changed from a parameter array to a normal array of objects. This is a **breaking change**. 
 
-Old Code:
+#### Old Code
 
 ```js
   const result = compose(a, b);
 ```
 
-New Code:
+#### New Code
 
 ```js
   const result = compose([a, b]);
 ```
+
+As a result of this change, options can now be provided to the compose method. The ```hide``` option in now available.
+
+```js
+import { compose } from "cooperate";
+import assert from "assert";
+
+// Assume all three capabilities here support a property called isWorking.
+import capability1 from "./ capability1";
+import capability2 from "./ capability2"; 
+import capability3 from "./ capability3";
+
+const service = compose([capability1, capability2, capability3], { hide: ["isWorking"] });
+
+// no naming collisions and no isWorking property on the resulting object
+assert(service.isWorking === undefined);
+```
+
 
 ### 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ assert(Object.getOwnPropertyDescriptor(repo, "_db") === undefined);
 
 With any form of composition you will eventually come across a problem with two things that have the same name. **cooperate** will throw an error if you try and do this as it cannot decide what to do without your help. 
 
-To help with this problem, **cooperate** provides the ```mapMembers()``` function.
+### Mapping Members
 
-### Example 1
+To help with this problem, **cooperate** provides the ```mapMembers()``` function. This lets you define your method forward rules per object.
+
+#### Example 1
 
 ```js
 import { compose, mapMembers } from "cooperate";
@@ -136,7 +138,7 @@ assert(repo.findSalesById);
 assert(repo.findById === undefined);
 ```
 
-### Example 2
+#### Example 2
 
 ```js
 
@@ -161,10 +163,13 @@ const salesWithMapping = mapMembers(sale)
 const combinedRepo = compose([productWithMapping, salesWithMapping]);
 
 ```
-Methods that you don't want to expose can also being hidden if required.
+### Hiding Members
+
+The ```mapMembers()``` can also be used with members that you don't want to expose on the **cooperate** object. This can be achieved with the ```hide()``` method.
 
 ```js
 import { compose, mapMembers } from "cooperate";
+import assert from "assert";
 
 const genericFeatures = new GenericFeatures(db);
 const specificFeatures = new SpecificFeatures(db);
@@ -178,5 +183,20 @@ const repo = compose([genericWithMapping, specificFeatures]);
 assert(repo.findSalesById);
 assert(repo.findById === undefined);
 assert(repo.deleteItem === undefined);
+```
+If the object you are trying to compose have a uniform interface then there is also an option on the ```compose()``` method to make this easier.
 
+```js
+import { compose } from "cooperate";
+import assert from "assert";
+
+// Assume all three capabilities here support a property called isWorking.
+import capability1 from "./ capability1";
+import capability2 from "./ capability2"; 
+import capability3 from "./ capability3";
+
+const service = compose([capability1, capability2, capability3], { hide: ["isWorking"] });
+
+// no naming collisions and no isWorking property on the resulting object
+assert(service.isWorking === undefined);
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { compose } from "cooperate";
 const capability1 = new Capability1();
 const capability2 = new Capability2();
 
-const combined = compose(capability1, capability2);
+const combined = compose([capability1, capability2]);
 ```
 
 JavaScript does not really have the concept of privacy but it is very common for developers to use an ```_``` to mark methods as private. **cooperate** follows this convention and will not expose anything that begins or ends with an ```_``` on the combined object.
@@ -99,7 +99,7 @@ const db = {};
 const genericFeatures = new GenericFeatures(db);
 const specificFeatures = new SpecificFeatures(db);
 
-const repo = compose(genericFeatures, specificFeatures);
+const repo = compose([genericFeatures, specificFeatures]);
 
 // Creates an object with no shared state
 assert(repo.findById);
@@ -129,7 +129,7 @@ const specificFeatures = new SpecificFeatures(db);
 const genericWithMapping = mapMembers(genericFeatures)
   .map("findById").to("findSalesById");
 
-const repo = compose(genericWithMapping, specificFeatures);
+const repo = compose([genericWithMapping, specificFeatures]);
 
 // Method is remapped
 assert(repo.findSalesById);
@@ -158,7 +158,7 @@ const salesWithMapping = mapMembers(sale)
   .map("insertItem").to("insertSale")
   .map("deleteItem").to("deleteSale");
 
-const combinedRepo = compose(productWithMapping, salesWithMapping);
+const combinedRepo = compose([productWithMapping, salesWithMapping]);
 
 ```
 Methods that you don't want to expose can also being hidden if required.
@@ -173,7 +173,7 @@ const genericWithMapping = mapMembers(genericFeatures)
   .map("findById").to("findSalesById")
   .hide("deleteItem");
 
-const repo = compose(genericWithMapping, specificFeatures);
+const repo = compose([genericWithMapping, specificFeatures]);
 
 assert(repo.findSalesById);
 assert(repo.findById === undefined);

--- a/src/test/example-test.js
+++ b/src/test/example-test.js
@@ -42,7 +42,7 @@ const db = {};
 const genericFeatures = new GenericFeatures(db);
 const specificFeatures = new SpecificFeatures(db);
 
-const repo = compose(genericFeatures, specificFeatures);
+const repo = compose([genericFeatures, specificFeatures]);
 
 // Creates an object with no shared state and does not expose private methods
 assert(repo.findById);

--- a/src/test/index-test.js
+++ b/src/test/index-test.js
@@ -248,7 +248,7 @@ group("The compose() function", () => {
     lab.test("An undefined hide option has no negative effects", done =>
       noNegativeOptionsEffect(done, { hide: undefined }));
 
-    lab.test("An empty hide option has no negative effects", done =>
+    lab.test("An empty array hide option has no negative effects", done =>
       noNegativeOptionsEffect(done, { hide: [] }));
 
     lab.test("it can hide a method properly when the option is supplied", done => {

--- a/src/test/mapMembers-test.js
+++ b/src/test/mapMembers-test.js
@@ -74,7 +74,7 @@ group("The mapMembers() function", () => {
 
     lab.test("the cooperate wrapper is correct", done => {
 
-      const result = compose(raw, descriptor);
+      const result = compose([raw, descriptor]);
 
       expect(result).to.be.an.object();
       expect(result.__cooperate).to.be.an.object();
@@ -86,7 +86,7 @@ group("The mapMembers() function", () => {
 
     lab.test("the mapping of a method alters the output of compose correctly", done => {
 
-      const result = compose(raw, descriptor);
+      const result = compose([raw, descriptor]);
 
       expect(result.getItem).to.be.a.function();
       expect(result.getTestItem).to.be.a.function();
@@ -99,7 +99,7 @@ group("The mapMembers() function", () => {
 
     lab.test("the mapping of a property alters the output of compose correctly", done => {
 
-      const result = compose(raw, descriptor);
+      const result = compose([raw, descriptor]);
 
       expect(result.uniqueValue).to.equal("raw-object-1");
       expect(result.moreUniqueValue).to.equal("object-1");
@@ -180,7 +180,7 @@ group("The hide() method", () => {
 
       descriptor.hide("getItem");
 
-      const result = compose(descriptor);
+      const result = compose([descriptor]);
 
       expect(result).to.be.an.object();
       expect(result.getItem).to.be.undefined();
@@ -196,7 +196,7 @@ group("The hide() method", () => {
 
       descriptor.hide("uniqueValue");
 
-      const result = compose(descriptor);
+      const result = compose([descriptor]);
 
       expect(result).to.be.an.object();
       expect(result.uniqueValue).to.be.undefined();

--- a/src/test/testClasses.js
+++ b/src/test/testClasses.js
@@ -78,11 +78,19 @@ export class MultipleC {
   three() {
     return this.three.name;
   }
+
+  tres() {
+    return this.tres.name;
+  }
 }
 
 export class MultipleCollision {
   three() {
     return this.three.name;
+  }
+
+  trois() {
+    return this.trois.name;
   }
 }
 


### PR DESCRIPTION
The method signature for compose has been changed from a parameter array to a normal array of objects. This is a **breaking change**. 

#### Old Code

```js
  const result = compose(a, b);
```

#### New Code

```js
  const result = compose([a, b]);
```

As a result of this change, options can now be provided to the compose method. The ```hide``` option in now available.

```js
import { compose } from "cooperate";
import assert from "assert";

// Assume all three capabilities here support a property called isWorking.
import capability1 from "./ capability1";
import capability2 from "./ capability2"; 
import capability3 from "./ capability3";

const service = compose([capability1, capability2, capability3], { hide: ["isWorking"] });

// no naming collisions and no isWorking property on the resulting object
assert(service.isWorking === undefined);
```

This address #5 

